### PR TITLE
Update Agent version to 1.1.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM openjdk:8u171-jdk-alpine3.7
 MAINTAINER Cory ODaniel "docker@coryodaniel.com"
 
-ENV AGENT_VERSION=1.1.3 \
+ENV AGENT_VERSION=1.1.4 \
     JAVA_START_HEAP=256m \
     JAVA_MAX_HEAP=512m \
     LOG_LEVEL=INFO


### PR DESCRIPTION
Hi, Cory. 

Thank you for setting up this container. It helped me a lot to put the Agent up and running in production. 

There is an [updated version](https://github.com/awslabs/amazon-kinesis-agent/releases/tag/1.1.4) of the Agent at the main repository.

I propose a PR that would also update the version in the Dockerfile and in the container. 

Best regards,

Gustavo